### PR TITLE
Fix getClassSchedule

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class StudentVueClient {
         if (typeof termIndex !== 'undefined') {
             params.TermIndex = termIndex;
         }
-        return this._xmlJsonSerialize(this._makeServiceRequest('StudentClassList'));
+        return this._xmlJsonSerialize(this._makeServiceRequest('StudentClassList', params));
     }
 
     getSchoolInfo() {


### PR DESCRIPTION
Fixes the bug where it doesn't send the term index in `getClassSchedule(termIndex)`